### PR TITLE
Fix read required option

### DIFF
--- a/commands/read.js
+++ b/commands/read.js
@@ -7,10 +7,7 @@ module.exports = {
   data: new SlashCommandBuilder()
     .setName('read')
     .addStringOption((option) =>
-      option
-        .setName('text')
-        .setDescription('喋らせたい内容')
-        .setRequired(false),
+      option.setName('text').setDescription('喋らせたい内容').setRequired(true),
     )
 
     .setDescription('引数に渡されたメッセージを読み上げます。'),


### PR DESCRIPTION
read コマンドの option `text` は必須なので、 required を true にしました。