### PR TITLE
Pin actions to a full length commit SHA

### DIFF
--- a/.github/workflows/maintain-quality.yml
+++ b/.github/workflows/maintain-quality.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions