### PR TITLE
fix renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,11 +14,11 @@
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],
-      "labels": ["semver:none"]
+      "addLabels": ["semver:none"]
     },
     {
       "matchDepTypes": ["dependencies", "require"],
-      "labels": ["semver:patch"]
+      "addLabels": ["semver:patch"]
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
labels だと既存の配列が置き換えられるため