### PR TITLE
ci: Update maintain-quality.yml

### DIFF
--- a/.github/workflows/maintain-quality.yml
+++ b/.github/workflows/maintain-quality.yml
@@ -2,6 +2,7 @@ name: Maintain code quality
 
 on:
   push:
+    branches: ['**']
   pull_request:
   pull_request_review:
 
@@ -11,7 +12,6 @@ permissions:
 jobs:
   lint:
     name: Lint
-    if: contains(fromJSON('["push", "pull_request_review"]'), github.event_name) || github.event.pull_request.head.repo.fork
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout


### PR DESCRIPTION
- tagプッシュ時には動かないようにした
- push と pull_request では GITHUB_SHA が異なるので両方で動かしておくべきそう