### PR TITLE
chore: remove `container_name` specification

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,6 @@
 services:
   discordbot-pow:
     image: discordbot-pow
-    container_name: discordbot-pow
     build: .
     pull_policy: build
     env_file: .env


### PR DESCRIPTION
Makes it possible to avoid container name conflicts.