### PR TITLE
fix: make cachedUserSettings actually work

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -34,9 +34,15 @@ export async function getUserSetting(id: string): Promise<userSetting> {
       },
     })
 
+    // A concurrent setUserSetting may have refreshed the cache while
+    // the query was running, so do not overwrite it with the stale result.
+    const updatedCachedUserSetting = cachedUserSettings.get(id)
+    if (updatedCachedUserSetting !== undefined) return updatedCachedUserSetting
+
     if (userSetting === null) {
       return await setUserSetting(randomUserSetting(BigInt(id)))
     }
+    cachedUserSettings.set(id, userSetting)
     return userSetting
   } catch (err) {
     if (
@@ -52,7 +58,6 @@ export async function getUserSetting(id: string): Promise<userSetting> {
 export async function setUserSetting(
   setting: userSetting,
 ): Promise<userSetting> {
-  cachedUserSettings.delete(String(setting.id))
   try {
     const userSetting = await prisma.userSetting.upsert({
       where: { id: BigInt(setting.id) },
@@ -69,6 +74,8 @@ export async function setUserSetting(
       },
     })
 
+    // Update the cache only after the DB write succeeds.
+    cachedUserSettings.set(String(setting.id), userSetting)
     return userSetting
   } catch (err) {
     if (


### PR DESCRIPTION
## Background

`cachedUserSettings` was never populated on read, and `setUserSetting()` deleted the entry before writing to the DB, so the in-memory cache was effectively non-functional.

## Changes

- `getUserSetting()` now stores DB results in the cache on a cache miss (including newly created random settings)
- `setUserSetting()` now updates the cache only after the upsert succeeds, leaving the existing cache untouched on failure
- `getUserSetting()` re-checks the cache after the DB query so a new cache entry from a concurrent `setUserSetting()` is not overwritten by a stale SELECT result

## Verification

- `pnpm lint`: passed
- `pnpm check:types`: passed
- `pnpm build`: passed
- `pnpm format:check`: passed
- tests: not run because the repository has no test infrastructure